### PR TITLE
fix: missing PRN in xlsx.mini

### DIFF
--- a/mini.lst
+++ b/mini.lst
@@ -22,6 +22,7 @@ bits/31_rels.js
 bits/33_coreprops.js
 bits/34_extprops.js
 bits/35_custprops.js
+bits/40_harb.js
 bits/42_sstxml.js
 bits/46_stycommon.js
 bits/47_styxml.js


### PR DESCRIPTION
# Issue

https://github.com/SheetJS/sheetjs/issues/1760

# Description

Based on my investigation, it seems like the function `read_prn` in the mini is missing `PRN` when it tries to read a string of CSV file.

This is just my hunch to add the `PRN` declaration as part of the `mini` build. 